### PR TITLE
Bump up the version to 1.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION=1.15.3
+KUBERNETES_VERSION=1.16.0
 DEBIAN_BASE=k8s.gcr.io/debian-base-amd64:0.4.1
 
 KUBE_CONFORMANCE_IMAGE="docker.io/zlabjp/kube-conformance:$(KUBERNETES_VERSION)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is an example for running e2e tests for the CSI hostpath driver:
 
 ```bash
 KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-docker run --init --rm -w "/workspace" -v "$KUBECONFIG:/config" -v "${PWD}:/workspace" docker.io/zlabjp/kube-conformance:1.15.3 \
+docker run --init --rm -w "/workspace" -v "$KUBECONFIG:/config" -v "${PWD}:/workspace" docker.io/zlabjp/kube-conformance:1.16.0 \
   ginkgo -p \
     --focus='External.Storage.*csi-hostpath' \
     --skip='\[Feature:|\[Disruptive\]' \


### PR DESCRIPTION
This PR bumps up the version of Kubernetes to 1.16.0.