### PR TITLE
Bump up the version to 1.17.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,12 +9,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the image
       run: make build
-    - uses: engineerd/setup-kind@v0.1.0
+    - uses: engineerd/setup-kind@v0.2.0
       with:
-        image: kindest/node:v1.16.1
+        image: kindest/node:v1.17.0
     - name: Run e2e tests using the image
       run: |
-        export KUBECONFIG="$(kind get kubeconfig-path)"
         kubectl cluster-info
         make test
     - name: Docker Login

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN set -x && \
     chmod +x kubectl
 
 FROM ${DEBIAN_BASE}
+RUN set -x && \
+    apt-get update -qq && \
+    apt-get install -qq -y bash jq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=kubernetes-test kubernetes/test/bin/e2e.test /usr/local/bin/
 COPY --from=kubernetes-test kubernetes/test/bin/ginkgo /usr/local/bin/
 COPY --from=kubectl kubectl /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION=1.16.0
+KUBERNETES_VERSION=1.17.0
 DEBIAN_BASE=k8s.gcr.io/debian-base-amd64:0.4.1
 
 KUBE_CONFORMANCE_IMAGE="docker.io/zlabjp/kube-conformance:$(KUBERNETES_VERSION)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is an example for running e2e tests for the CSI hostpath driver:
 
 ```bash
 KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-docker run --init --rm -w "/workspace" -v "$KUBECONFIG:/config" -v "${PWD}:/workspace" docker.io/zlabjp/kube-conformance:1.16.0 \
+docker run --init --rm -w "/workspace" -v "$KUBECONFIG:/config" -v "${PWD}:/workspace" docker.io/zlabjp/kube-conformance:1.17.0 \
   ginkgo -p \
     --focus='External.Storage.*csi-hostpath' \
     --skip='\[Feature:|\[Disruptive\]' \


### PR DESCRIPTION
This PR bumps up the version of e2e-test to Kubernetes 1.17.0. In addition, useful command-line tools, bash and jq are added.