### PR TITLE
Bump the version to v1.18.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
       run: make build
     - uses: engineerd/setup-kind@v0.2.0
       with:
-        image: kindest/node:v1.17.0
+        image: kindest/node:v1.18.0
     - name: Run e2e tests using the image
       run: |
         kubectl cluster-info

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION=1.17.0
+KUBERNETES_VERSION=1.18.0
 DEBIAN_BASE=k8s.gcr.io/debian-base-amd64:0.4.1
 
 KUBE_CONFORMANCE_IMAGE="docker.io/zlabjp/kube-conformance:$(KUBERNETES_VERSION)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is an example for running e2e tests for the CSI hostpath driver:
 
 ```bash
 KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
-docker run --init --rm -w "/workspace" -v "$KUBECONFIG:/config" -v "${PWD}:/workspace" docker.io/zlabjp/kube-conformance:1.17.0 \
+docker run --init --rm -w "/workspace" -v "$KUBECONFIG:/config" -v "${PWD}:/workspace" docker.io/zlabjp/kube-conformance:1.18.0 \
   ginkgo -p \
     --focus='External.Storage.*csi-hostpath' \
     --skip='\[Feature:|\[Disruptive\]' \

--- a/hack/update-kubernetes-version.sh
+++ b/hack/update-kubernetes-version.sh
@@ -11,3 +11,4 @@ fi
 
 sed -i -e "s#kube-conformance:[0-9.]\+#kube-conformance:$kubernetes_version#" README.md
 sed -i -e "s/KUBERNETES_VERSION=[0-9\.]\+/KUBERNETES_VERSION=$kubernetes_version/" Makefile
+sed -i -e "s#image: kindest/node:v[0-9\.]\+#image: kindest/node:v${kubernetes_version}#" .github/workflows/main.yaml


### PR DESCRIPTION
This PR bumps up the version of e2e-test to Kubernetes 1.18.0. 